### PR TITLE
Add CLI version flag and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.1] - 2024-04-05
+### Added
+- `--version` command line option.
+- English user messages and additional docstrings.
+- Changelog file and README improvements.
+- Test for CLI version output.
+
+## [0.2.0] - 2024-04-05
+### Added
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Record information about regular files (name, size, creation and modification ti
 ## Features
 
 - Simple command line interface
+- Display program version with `--version`
 - Batch commits for good performance
 - Error logging with timestamps
 - Installable via `pyproject.toml`
@@ -34,12 +35,15 @@ python -m filescan2db <directory>
 ```
 
 See `filescan2db --help` for optional arguments.
+Use `filescan2db --version` to display the current version.
 
 ## Tests
 
 ```bash
 pytest
 ```
+
+See `CHANGELOG.md` for release notes.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "filescan2db"
-version = "0.2.0"
+version = "0.2.1"
 description = "Scan directories recursively and store file metadata in SQLite"
 authors = [
     {name = "Tobias"}

--- a/src/filescan2db/__main__.py
+++ b/src/filescan2db/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/filescan2db/main.py
+++ b/src/filescan2db/main.py
@@ -8,6 +8,8 @@ import sqlite3
 import time
 from typing import Dict
 
+from . import __version__
+
 DB_NAME = "files.db"
 LOG_NAME = "error.log"
 COMMIT_EVERY = 10000
@@ -108,19 +110,22 @@ def scan_directory(
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+
     parser = argparse.ArgumentParser(
         description="Recursively scan a directory and store file metadata in SQLite",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("path", help="Directory to scan")
     parser.add_argument(
         "--db",
         default=DB_NAME,
-        help=f"Output SQLite database file (default: {DB_NAME})",
+        help="Output SQLite database file",
     )
     parser.add_argument(
         "--log",
         default=LOG_NAME,
-        help=f"Log file for errors (default: {LOG_NAME})",
+        help="Log file for errors",
     )
     parser.add_argument(
         "--commit-every",
@@ -128,15 +133,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=COMMIT_EVERY,
         help="Commit after processing this many files",
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the command line interface and return an exit status."""
+
     args = parse_args(argv)
     target = args.path
 
     if not os.path.isdir(target):
-        print(f"Fehler: '{target}' ist kein Verzeichnis.")
+        print(f"Error: '{target}' is not a directory.")
         return 2
 
     setup_logging(args.log)
@@ -145,7 +157,7 @@ def main(argv: list[str] | None = None) -> int:
     start = time.time()
     total = scan_directory(target, conn, cur, commit_every=args.commit_every)
     duration = time.time() - start
-    print(f"Fertig: {total} Dateien in {duration:.1f} s gescannt.")
+    print(f"Done: scanned {total} files in {duration:.1f} s.")
     return 0
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,10 @@ import pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]/"src"))
 
 from filescan2db.main import scan_directory, setup_db
+from filescan2db import __version__
+import subprocess
+import os
+
 
 
 def test_scan_directory(tmp_path):
@@ -19,3 +23,15 @@ def test_scan_directory(tmp_path):
     cur.execute("SELECT name FROM files")
     assert cur.fetchone()[0] == "file.txt"
     conn.close()
+
+
+def test_version_cli(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(pathlib.Path(__file__).resolve().parents[1]/"src")
+    result = subprocess.run(
+        [sys.executable, "-m", "filescan2db", "--version"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.stdout.strip().endswith(__version__)


### PR DESCRIPTION
## Summary
- add CHANGELOG documenting releases
- support `--version` option in CLI
- translate console messages to English and document usage
- provide `__main__.py` for `python -m filescan2db`
- update tests for version flag
- bump version to 0.2.1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460c95e02c8329bd2e801161e884ce