### PR TITLE
Release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-06-10
+### Changed
+- Aligned README flag descriptions with CLI options
+- Bumped project version to 0.3.2
+
 ## [0.3.1] - 2025-06-09
 ### Changed
 - Updated README examples and flag overview to match CLI options

--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ filescan2db --version
 
 ### Flag Overview
 
-- `--db FILE` – SQLite database file
-- `--log FILE` – log errors to FILE
-- `--hash[=ALG1,ALG2]` – enable hashing. Omit value for interactive selection
+- `--db FILE` – output SQLite database file (default `files.db`)
+- `--log FILE` – log errors to FILE (default `filescan2db_errors.log`)
+- `--hash[=ALG1,ALG2]` – enable hashing; omit value for interactive selection
 - `-u`, `--updatedb` DBASE – update an existing database with hash columns
 - `--safe` – create a backup when updating a database
-- `--commit-every N` – commit after N files
 - `-l` – suppress log file creation
 - `-fo` – force overwrite of the log file
 - `-fa` – force append to the log file without prompts
+- `--commit-every N` – commit after N files
 - `--help`, `--version` – show CLI help or version
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "filescan2db"
-version = "0.3.1"
+version = "0.3.2"
 description = "Scan directories recursively and store file metadata in SQLite"
 authors = [
     {name = "Tobias"}


### PR DESCRIPTION
## Summary
- bump version to 0.3.2
- sync README flag list with the CLI
- note changes in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d6ee99a48329bb9c8a45a3e5ec9e